### PR TITLE
Customizable slice names

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,15 @@ Usage:
 
 Flags:
 
+  -file-names-var string
+        name of the generated file names slice (default "fileNames")
+  -files-var string
+        name of the generated files slice (default "files")
   -out file
         output go file (default "files.go")
   -pkg package
         package name of the go file (default "main")
+  -verbose
 ```
 
 ## Example

--- a/main.go
+++ b/main.go
@@ -16,9 +16,9 @@ const tmpl = `
 
 package {{.Package}}
 
-var fileNames = []string{ {{range $name, $bytes := .Files}}"{{$name}}",{{end}} }
+var {{.FileNamesVar}} = []string{ {{range $name, $bytes := .Files}}"{{$name}}",{{end}} }
 
-var files = map[string][]byte{
+var {{.FilesVar}} = map[string][]byte{
 {{range $name, $bytes := .Files}}
 	"{{$name}}": []byte{ {{range $bytes}}{{.}},{{end}} },
 {{end}}
@@ -26,13 +26,17 @@ var files = map[string][]byte{
 `
 
 type tmplData struct {
-	Package string
-	Files   map[string][]byte
+	Package      string
+	Files        map[string][]byte
+	FileNamesVar string
+	FilesVar     string
 }
 
 func main() {
 	out := flag.String("out", "files.go", "output go `file`")
 	pkg := flag.String("pkg", "main", "`package` name of the go file")
+	filesVar := flag.String("files-var", "files", "name of the generated files slice")
+	fileNamesVar := flag.String("file-names-var", "fileNames", "name of the generated file names slice")
 	verbose := flag.Bool("verbose", false, "")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Embedfiles embeds files in the paths into a map in a go file.\n\n")
@@ -96,7 +100,7 @@ func main() {
 	}
 
 	buf := bytes.Buffer{}
-	err = t.Execute(&buf, tmplData{Package: *pkg, Files: files})
+	err = t.Execute(&buf, &tmplData{Package: *pkg, Files: files, FilesVar: *filesVar, FileNamesVar: *fileNamesVar})
 	if err != nil {
 		printErr("generating code", err)
 		return


### PR DESCRIPTION
Useful against name collisions, or to generate public identifiers (as I had both needs in the past)

Example execution:
```
embedfiles --files-var=MyFiles --file-names-var=MyFileNames file1 morefiles
```
Example output:
```go
// Generated by 4d63.com/embedfiles.

package main

var MyFileNames = []string{
        "file1", "morefiles/file2",
}

var MyFiles = map[string][]byte{

        "file1": []byte{
                31, 139, 8, 0, 0, 0, 0, 0, 2, 255, 202, 72, 205, 201, 201, 87, 40, 207, 47, 202, 73, 225, 2, 4, 0, 0, 255, 255, 45, 59, 8, 175, 12, 0, 0, 0,
        },

        "morefiles/file2": []byte{
                31, 139, 8, 0, 0, 0, 0, 0, 2, 255, 42, 207, 200, 87, 72, 44, 74, 85, 168, 204, 47, 181, 231, 2, 4, 0, 0, 255, 255, 138, 46, 37, 108, 13, 0, 0, 0,
        },
}
```